### PR TITLE
Propagate "EOF" error as io.EOF

### DIFF
--- a/kit/x/io/io.go
+++ b/kit/x/io/io.go
@@ -52,9 +52,9 @@ func (y YReader) Read(p []byte) (n int, err error) {
 		panic("corrupt i/o server")
 	}
 	copy(p, q)
-	// if err != nil {
-	// 	err = io.EOF
-	// }
+	if err != nil && err.Error() == "EOF" {
+		err = io.EOF
+	}
 	return len(q), err
 }
 


### PR DESCRIPTION
When the WriteCloser of a channel is closed, the Reader receives an "EOF" error that is not equal to io.EOF. This makes ioutil.ReadAll return an "EOF" error even though it's [documentation](http://golang.org/pkg/io/ioutil/#ReadAll) says, it should not do so.

A demo for this problem is available [here](https://github.com/fourcube/circuit_eof). 
