### PR TITLE
runproc sample

### DIFF
--- a/cmd/circuit/main.go
+++ b/cmd/circuit/main.go
@@ -220,6 +220,17 @@ func main() {
 			},
 		},
 		{
+			Name:   "runproc",
+			Usage:  "Run a process element and return output on stdout",
+			Action: runproc,
+			Flags: []cli.Flag{
+				cli.StringFlag{"dial, d", "", "circuit member to dial into"},
+				cli.StringFlag{"discover", "228.8.8.8:8822", "Multicast address for peer server discovery"},
+				cli.BoolFlag{"scrub", "scrub the process anchor automatically on exit"},
+				cli.StringFlag{"hmac", "", "File containing HMAC credentials. Use RC4 encryption."},
+			},
+		},
+		{
 			Name:   "signal",
 			Usage:  "Send a signal to a running process",
 			Action: sgnl,


### PR DESCRIPTION
This was pretty easy to get going.  It still has json on stdin, but it closes stdin, returns stdout, and scrubs the element.  Is this a decent way to proceed?  This already makes it much more shell friendly. 
