### PR TITLE
switch from syscall.Dup2 to syscall.Dup3 to fix aarch64 build

### DIFF
--- a/kit/debug/sigpanic_save_panic_trace.go
+++ b/kit/debug/sigpanic_save_panic_trace.go
@@ -25,7 +25,7 @@ func SavePanicTrace() {
 	if err != nil {
 		panic("dumper (no file) " + r.(fmt.Stringer).String())
 	}
-	syscall.Dup2(int(file.Fd()), int(os.Stderr.Fd()))
+	syscall.Dup3(int(file.Fd()), int(os.Stderr.Fd()), 0)
 	// TRY: defer func() { file.Close() }()
 	panic("dumper " + r.(string))
 }


### PR DESCRIPTION
Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>